### PR TITLE
修复SQ回放音质不匹配问题

### DIFF
--- a/Unblock163MusicClient/Program.cs
+++ b/Unblock163MusicClient/Program.cs
@@ -207,28 +207,32 @@ namespace Unblock163MusicClient
                     // This is called when player tries to get the URL for a song.
                     else if (url.Contains("/eapi/song/enhance/player/url"))
                     {
-                        string bitrate = GetPlaybackBitrate(s.GetResponseBodyAsString());
-                        // Whatever current playback bitrate is, it's overriden.
-                        if (!string.IsNullOrEmpty(Configuration.ForcePlaybackBitrate))
-                        {
-                            bitrate = Configuration.ForcePlaybackBitrate;
-                            Console.WriteLine($"Plackback bitrate is forced set to {bitrate}");
-                        }
-                        // We receive a wrong bitrate...
-                        else if (bitrate == "0")
-                        {
-                            bitrate = string.IsNullOrEmpty(Configuration.ForcePlaybackBitrate) ? "320000" : Configuration.ForcePlaybackBitrate;
-                            Console.WriteLine($"Plackback bitrate is forced set to {bitrate} as the given bitrate is not valid.");
-                        }
-                        else if (bitrate != Configuration.PlaybackBitrate)
-                        {
-                            Console.WriteLine($"Plackback bitrate is switched to {bitrate} from {Configuration.PlaybackBitrate}");
-                        }
-                        Configuration.PlaybackBitrate = bitrate;
-                        Configuration.PlaybackQuality = ParseBitrate(Configuration.ForcePlaybackBitrate);
+//						Console.WriteLine (s.GetResponseBodyAsString ());
+						string code = GetPlayResponseCode (s.GetResponseBodyAsString ());
+						if (code == "404") {
+							string bitrate = GetPlaybackBitrate (s.GetResponseBodyAsString ());
+							// Whatever current playback bitrate is, it's overriden.
+							if (!string.IsNullOrEmpty (Configuration.ForcePlaybackBitrate)) {
+								bitrate = Configuration.ForcePlaybackBitrate;
+								Console.WriteLine ($"Plackback bitrate is forced set to {bitrate}");
+							}
+	                        // We receive a wrong bitrate...
+	                        else if (bitrate == "0") {
+								bitrate = string.IsNullOrEmpty (Configuration.ForcePlaybackBitrate) ? "320000" : Configuration.ForcePlaybackBitrate;
+								Console.WriteLine ($"Plackback bitrate is forced set to {bitrate} as the given bitrate is not valid.");
+							} else if (bitrate != Configuration.PlaybackBitrate) {
+								Console.WriteLine ($"Plackback bitrate is switched to {bitrate} from {Configuration.PlaybackBitrate}");
+							}
+							Configuration.PlaybackBitrate = bitrate;
+							Configuration.PlaybackQuality = ParseBitrate (Configuration.ForcePlaybackBitrate);
 
-                        string modified = ModifyPlayerApi(s.GetResponseBodyAsString());
-                        s.utilSetResponseBody(modified);
+							string modified = ModifyPlayerApi (s.GetResponseBodyAsString ());
+							s.utilSetResponseBody (modified);
+						} else {
+							Console.WriteLine ($"Get url from netease directly.");
+							string music_url = GetPlayResponseUrl (s.GetResponseBodyAsString ());
+							Console.WriteLine($"Song URL = {music_url}");
+						}
                     }
                     // When we try to download a song, the API tells whether it exceeds the limit. Of course no!
                     else if (url.Contains("/eapi/song/download/limit"))
@@ -239,33 +243,69 @@ namespace Unblock163MusicClient
                     // Similar to the player URL API, but used for download.
                     else if (url.Contains("/eapi/song/enhance/download/url"))
                     {
-                        string bitrate = GetDownloadBitrate(s.GetResponseBodyAsString());
+//						Console.WriteLine (s.GetResponseBodyAsString ());
+						string code = GetDownloadResponseCode (s.GetResponseBodyAsString ());
+						if (code == "404") {
+	                        string bitrate = GetDownloadBitrate(s.GetResponseBodyAsString());
 
-                        // Whatever current download bitrate is, it's overriden.
-                        if (!string.IsNullOrEmpty(Configuration.ForceDownloadBitrate))
-                        {
-                            bitrate = Configuration.ForceDownloadBitrate;
-                            Console.WriteLine($"Download bitrate is forced set to {bitrate}");
-                        }
-                        // We receive a wrong bitrate...
-                        else if (bitrate == "0")
-                        {
-                            bitrate = string.IsNullOrEmpty(Configuration.ForceDownloadBitrate) ? "320000" : Configuration.ForceDownloadBitrate;
-                            Console.WriteLine($"Download bitrate is forced set to {bitrate} as the given bitrate is not valid.");
-                        }
-                        else if (bitrate != Configuration.DownloadBitrate)
-                        {
-                            Console.WriteLine($"Download bitrate is switched to {bitrate} from {Configuration.DownloadBitrate}");
-                        }
-                        Configuration.DownloadBitrate = bitrate;
-                        Configuration.DownloadQuality = ParseBitrate(bitrate);
+	                        // Whatever current download bitrate is, it's overriden.
+	                        if (!string.IsNullOrEmpty(Configuration.ForceDownloadBitrate))
+	                        {
+	                            bitrate = Configuration.ForceDownloadBitrate;
+	                            Console.WriteLine($"Download bitrate is forced set to {bitrate}");
+	                        }
+	                        // We receive a wrong bitrate...
+	                        else if (bitrate == "0")
+	                        {
+	                            bitrate = string.IsNullOrEmpty(Configuration.ForceDownloadBitrate) ? "320000" : Configuration.ForceDownloadBitrate;
+	                            Console.WriteLine($"Download bitrate is forced set to {bitrate} as the given bitrate is not valid.");
+	                        }
+	                        else if (bitrate != Configuration.DownloadBitrate)
+	                        {
+	                            Console.WriteLine($"Download bitrate is switched to {bitrate} from {Configuration.DownloadBitrate}");
+	                        }
+	                        Configuration.DownloadBitrate = bitrate;
+	                        Configuration.DownloadQuality = ParseBitrate(bitrate);
 
-                        string modified = ModifyDownloadApi(s.GetResponseBodyAsString());
-                        s.utilSetResponseBody(modified);
+	                        string modified = ModifyDownloadApi(s.GetResponseBodyAsString());
+	                        s.utilSetResponseBody(modified);
+						} else {
+							Console.WriteLine ($"Get url from netease directly.");
+							string music_url = GetDownloadResponseUrl (s.GetResponseBodyAsString ());
+							Console.WriteLine($"Song URL = {music_url}");
+						}
                     }
                 }
             }
         }
+
+		private static string GetPlayResponseCode(string apiResult)
+		{
+			JObject root = JObject.Parse(apiResult);
+			string code = root["data"][0]["code"].Value<string>();
+			return code;
+		}
+
+		private static string GetPlayResponseUrl(string apiResult)
+		{
+			JObject root = JObject.Parse(apiResult);
+			string music_url = root ["data"] [0] ["url"].Value<string> ();
+			return music_url;
+		}
+
+		private static string GetDownloadResponseCode(string apiResult)
+		{
+				JObject root = JObject.Parse(apiResult);
+				string code = root["data"]["code"].Value<string>();
+			return code;
+		}
+
+		private static string GetDownloadResponseUrl(string apiResult)
+		{
+			JObject root = JObject.Parse(apiResult);
+			string music_url = root ["data"] ["url"].Value<string> ();
+			return music_url;
+		}
 
         /// <summary>
         /// Get current playback bitrate from API result.

--- a/Unblock163MusicClient/Program.cs
+++ b/Unblock163MusicClient/Program.cs
@@ -209,7 +209,8 @@ namespace Unblock163MusicClient
                     {
 						Console.WriteLine (s.GetResponseBodyAsString ());
 						string code = GetPlayResponseCode (s.GetResponseBodyAsString ());
-						if (code != "200") {
+						int br = int.Parse(GetPlaybackBitrate(s.GetResponseBodyAsString ()));
+						if (code != "200" || br < 320000) {
 							string bitrate = GetPlaybackBitrate (s.GetResponseBodyAsString ());
 							// Whatever current playback bitrate is, it's overriden.
 							if (!string.IsNullOrEmpty (Configuration.ForcePlaybackBitrate)) {
@@ -245,7 +246,8 @@ namespace Unblock163MusicClient
                     {
 						Console.WriteLine (s.GetResponseBodyAsString ());
 						string code = GetDownloadResponseCode (s.GetResponseBodyAsString ());
-						if (code != "200") {
+						int br = int.Parse(GetDownloadBitrate(s.GetResponseBodyAsString ()));
+						if (code != "200" || br < 320000) {
 	                        string bitrate = GetDownloadBitrate(s.GetResponseBodyAsString());
 
 	                        // Whatever current download bitrate is, it's overriden.

--- a/Unblock163MusicClient/Program.cs
+++ b/Unblock163MusicClient/Program.cs
@@ -207,9 +207,9 @@ namespace Unblock163MusicClient
                     // This is called when player tries to get the URL for a song.
                     else if (url.Contains("/eapi/song/enhance/player/url"))
                     {
-//						Console.WriteLine (s.GetResponseBodyAsString ());
+						Console.WriteLine (s.GetResponseBodyAsString ());
 						string code = GetPlayResponseCode (s.GetResponseBodyAsString ());
-						if (code == "404") {
+						if (code != "200") {
 							string bitrate = GetPlaybackBitrate (s.GetResponseBodyAsString ());
 							// Whatever current playback bitrate is, it's overriden.
 							if (!string.IsNullOrEmpty (Configuration.ForcePlaybackBitrate)) {
@@ -243,9 +243,9 @@ namespace Unblock163MusicClient
                     // Similar to the player URL API, but used for download.
                     else if (url.Contains("/eapi/song/enhance/download/url"))
                     {
-//						Console.WriteLine (s.GetResponseBodyAsString ());
+						Console.WriteLine (s.GetResponseBodyAsString ());
 						string code = GetDownloadResponseCode (s.GetResponseBodyAsString ());
-						if (code == "404") {
+						if (code != "200") {
 	                        string bitrate = GetDownloadBitrate(s.GetResponseBodyAsString());
 
 	                        // Whatever current download bitrate is, it's overriden.

--- a/Unblock163MusicClient/Unblock163MusicClient.csproj
+++ b/Unblock163MusicClient/Unblock163MusicClient.csproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Unblock163MusicClient</RootNamespace>
     <AssemblyName>Unblock163MusicClient</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <IsWebBootstrapper>false</IsWebBootstrapper>
@@ -37,6 +37,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Externalconsole>true</Externalconsole>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -49,14 +50,6 @@
     <UseVSHostingProcess>false</UseVSHostingProcess>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="FiddlerCore4, Version=4.6.2.0, Culture=neutral, PublicKeyToken=67cb91587178ac5a, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\FiddlerCore4.dll</HintPath>
-    </Reference>
-    <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.6.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Windows.Forms" />
@@ -65,6 +58,12 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
+    <Reference Include="FiddlerCore4">
+      <HintPath>..\FiddlerCore4.dll</HintPath>
+    </Reference>
+    <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed">
+      <HintPath>..\packages\Newtonsoft.Json.6.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Program.cs" />


### PR DESCRIPTION
当付费用户使用该代理时，应正常播放的 SQ 音质也会被拦截，并重新返回 320Kbps 的回放链接。然后在客户端中音质显示为 SQ，但是下载的文件却是 mp3。

故在获取回放链接以及下载链接的 hack 前增加判断，如果网易返回的链接是正确的，并且码率为 320000 将不做 hack 处理。
